### PR TITLE
Convert quotes cog to use Mongo

### DIFF
--- a/cogs/quotes.py
+++ b/cogs/quotes.py
@@ -1,70 +1,81 @@
-from discord.ext import commands
-from .utils import checks
-import json
-import random
 import re
+from bson.objectid import ObjectId
+from discord.ext import commands
 
-FILE_NAME = 'quotes.json'
-INPUT_REGEX = re.compile(r'"(.+)" \- ((\S+\s*)+)')
-OUTPUT_FORMAT = '"{}" - {}'  # Quote - source
-LIST_FORMAT = "\n{} - "
+from .utils import checks
+
+# Matches something like: "Bring back the quaaludes" - Quaaludes Guy
+INPUT_REGEX = re.compile(r'"(?P<quote>.+)"\s*\-\s*(?P<source>(\S+\s*)+)')
+OUTPUT_FORMAT = '"{quote}" - {source}'
+OUTPUT_FORMAT_VERBOSE = '[{_id}] "{quote}" - {source}'
 MAX_WHISPER_LENGTH = 1500
-
-# Load all quotes
-
-try:
-    with open(FILE_NAME) as f:
-        quotes = json.load(f)
-except FileNotFoundError:
-    print(f"Warning: {FILE_NAME} not found")
-    quotes = []
 
 
 def setup(bot):
-    bot.add_cog(quotesCog(bot))
+    bot.add_cog(QuotesCog(bot))
 
 
-def save_quotes():
-    with open(FILE_NAME, 'w') as f:
-        json.dump(quotes, f, indent=4)
+def format_quote(quote, show_id=False):
+    fmt = OUTPUT_FORMAT_VERBOSE if show_id else OUTPUT_FORMAT
+    return fmt.format(**quote)
 
 
-def format_quote(quote):
-    return OUTPUT_FORMAT.format(quote[0], quote[1])
-
-
-class quotesCog:
+class QuotesCog:
     """Commands for quotes"""
 
     def __init__(self, bot):
         self.bot = bot
+        self.coll = bot.db.quotes  # Get the relevant Mongo collection
 
     @commands.command()
     async def quote(self, *args):
+        """
+        Gets a random quote. If args are given, will get a quote that matches
+        the args. The match is done against the quote text and the source.
+        """
+
         # If words were provided, use them to filter the quotes
         if args:
-            # Filter for a word
-            target = ' '.join(args)  # Combine the given words with spaces
-            selection = [q for q in quotes if target.lower() in q.lower()]
+            # Combine the given words with spaces and escape regex special chars
+            query_str = ' '.join(args)
+            # Caseless regex query for each field
+            field_query = {
+                '$regex': re.escape(query_str),
+                '$options': 'i',  # Case-insensitive
+            }
+            # Mongo uses AND queries by default by we want OR
+            query = {'$or': [
+                {'quote': field_query},
+                {'source': field_query},
+            ]}
         else:
-            # Choose from all quotes
-            selection = quotes
-        # If there are any quotes, select from those, otherwise print a message
-        if selection:
-            quote = random.choice(selection)
+            query = {}  # Match all docs
+
+        try:
+            # Query for a random quote and print it
+            quote = self.coll.aggregate([
+                {'$match': query},  # Match against the query
+                {'$sample': {'size': 1}},  # Select 1 random record
+            ]).next()  # Will raise an error if there are no results
             await self.bot.say(format_quote(quote))
-        else:
+        except StopIteration:
+            # No results from mongo
             await self.bot.say("No quotes!")
 
     # *args would not give ' " ' character for some reason
     @commands.command(pass_context=True)
     async def savequote(self, ctx):
+        """
+        Save the given quote
+        """
         args = ctx.message.content.split(' ')
         msg = ' '.join(args[1:])
         match = INPUT_REGEX.match(msg)
         if match:
-            quotes.append((match.group(1), match.group(2)))  # List of (quote, source)
-            save_quotes()
+            self.coll.insert_one({
+                'quote': match.group('quote'),
+                'source': match.group('source'),
+            })
             await self.bot.say("Added quote: " + msg)
         else:
             await self.bot.say("Quotes must be of the form '\"Quote\" - Source'")
@@ -72,34 +83,36 @@ class quotesCog:
     @commands.command()
     @checks.admin_or_permissions(manage_roles=True)
     async def showquotes(self):
-        quote_strs = [OUTPUT_FORMAT.format(*quote) for quote in quotes]
-        msg = '\n'.join(quote_strs)
-        msgs = []  # Used to split string into components so that each one is smaller than max size
-        while len(msg) > MAX_WHISPER_LENGTH:
-            try:
-                pos = msg.rfind('\n', end=MAX_WHISPER_LENGTH)
-            except ValueError:
-                self.bot.whisper("Something went wrong. Maybe there's a quote that's too long?")
-                return
-            msgs.append(msg[:pos])
-            msg = msg[pos:]
-        for quote in quotes:
-            msg += '\n' + OUTPUT_FORMAT.format(*quote)  # Unpack the quote for formatting
-            if len(msg) >= MAX_WHISPER_LENGTH:
-                await self.bot.whisper(msg)
-                msg = "\n"
-        await self.bot.whisper(msg)
+        """Get all quotes, including their IDs"""
+        quote_strs = [format_quote(quote, show_id=True) for quote in self.coll.find()]
+
+        # Discord has a max length for whispers, so we may have to break up
+        # the quote list into multiple messages to get around that. Build
+        # a list of lists, where each sublist is a group of quotes that will
+        # be merged into one message.
+        quote_groups = [[]]  # [[<quote1>, <quote2>], [<quote3>, <quote4>]]
+        last_group_size = 0
+        for quote in quote_strs:
+            last_group_size += (len(quote) + 1)  # +1 to account for newline char
+            if last_group_size <= MAX_WHISPER_LENGTH:
+                quote_group = quote_groups[-1]
+            else:
+                quote_group = []
+                quote_groups.append(quote_group)
+                last_group_size = 0
+            quote_group.append(quote)
+
+        # Merge each quote group into one string, then PM it
+        for quote_group in quote_groups:
+            msg = '\n'.join(quote_group)
+            await self.bot.whisper(msg)
 
     @commands.command(no_pm=True)
     @checks.admin_or_permissions(manage_roles=True)
-    async def removequote(self, index: int):
-        """Removes the indexed quote from list of quotes
-
-            Cannot be used in PMs"""
-        if 0 <= index < len(quotes):
-            to_remove = quotes[index]
-            del quotes[index]
-            save_quotes()
-            await self.bot.say("Removed: " + to_remove)
-        else:
-            await self.bot.say("Invalid index")
+    async def removequote(self, doc_id):
+        """Remove a quote by its ID"""
+        result = self.coll.delete_one({'_id': ObjectId(doc_id)})  # Adios, bitch
+        response = f"Removed {doc_id}" \
+            if result.deleted_count > 0 \
+            else "Unknown doc ID"  # Nothing was deleted
+        await self.bot.say(response)

--- a/migrations/quotes.py
+++ b/migrations/quotes.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pymongo import MongoClient
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--file', '-f', default='quotes.json',
+                        help='File to load old quotes data from')
+    parser.add_argument('--host', default='mongodb://db:27017')
+    parser.add_argument('--db', '-d', default='fatbot',
+                        help='Mongo DB name')
+    args = parser.parse_args()
+
+    db = MongoClient(args.host)[args.db]
+    coll = db.quotes
+
+    with open(args.file) as f:
+        quotes = json.load(f)
+    print(f'Inserting {len(quotes)} quotes...')
+    for quote, source in quotes:
+        coll.insert_one({'quote': quote, 'source': source})
+    print('Done!')


### PR DESCRIPTION
The only command that really changed is `removequote`, which went from specifying a quote by index to specifying by Mongo doc ID. I think it's better this way.